### PR TITLE
Always add mode attribute

### DIFF
--- a/src/fspec-fromarchive.c
+++ b/src/fspec-fromarchive.c
@@ -32,17 +32,6 @@ filetype(__LA_MODE_T ty)
     exit(1);
 }
 
-static int
-isdefaultmode(__LA_MODE_T ty, int mode)
-{
-    return (ty == AE_IFDIR && mode == 0755)
-        || (ty == AE_IFLNK && mode == 0755)
-        || (ty == AE_IFREG && mode == 0644)
-        || (ty == AE_IFIFO && mode == 0644)
-        || (ty == AE_IFBLK && mode == 0600)
-        || (ty == AE_IFCHR && mode == 0600);
-}
-
 int
 main (int argc, char **argv)
 {
@@ -96,9 +85,7 @@ main (int argc, char **argv)
 
         printf("%s\n", path);
         printf("type=%s\n", filetype(archive_entry_filetype(entry)));
-
-        if(!isdefaultmode(archive_entry_filetype(entry), archive_entry_perm(entry)))
-            printf("mode=%04o\n", archive_entry_perm(entry));
+        printf("mode=%04o\n", archive_entry_perm(entry));
 
         if (archive_entry_uid(entry) != 0)
             printf("uid=%lld\n", (long long)archive_entry_uid(entry));

--- a/src/fspec-fromdir.c
+++ b/src/fspec-fromdir.c
@@ -26,18 +26,6 @@ filetype(mode_t st_mode)
 }
 
 static int
-isdefaultmode(mode_t st_mode)
-{
-    int masked = st_mode & ~S_IFMT;
-    return (S_ISDIR(st_mode)  && masked == 0755)
-        || (S_ISLNK(st_mode)  && masked == 0755)
-        || (S_ISREG(st_mode)  && masked == 0644)
-        || (S_ISFIFO(st_mode) && masked == 0644)
-        || (S_ISBLK(st_mode)  && masked == 0600)
-        || (S_ISCHR(st_mode)  && masked == 0600);
-}
-
-static int
 printfspec(const char *fpath, const struct stat *sb,
             int tflag, struct FTW *ftwbuf)
 {
@@ -49,9 +37,7 @@ printfspec(const char *fpath, const struct stat *sb,
 
     printf("%s%s\n", prefix, fpath+2);
     printf("type=%s\n", filetype(sb->st_mode));
-
-    if (!isdefaultmode(sb->st_mode))
-        printf("mode=%04o\n", sb->st_mode & ~S_IFMT);
+    printf("mode=%04o\n", sb->st_mode & ~S_IFMT);
 
     if (!root_owned) {
         if (sb->st_uid != 0)

--- a/test/0001-fspec-archive-sanity.test
+++ b/test/0001-fspec-archive-sanity.test
@@ -29,9 +29,42 @@ devnum=2
 
 EOF
 
-fspec-tar < t.fspec | fspec-fromtar > out.fspec
-diff -u t.fspec out.fspec
+cat <<EOF > want.fspec
+foo
+type=reg
+mode=0700
+
+bar
+type=reg
+mode=0644
+
+baz/
+type=dir
+mode=0755
+
+fif
+type=fifo
+mode=0644
+
+dev/
+type=dir
+mode=0755
+
+dev/null
+type=chardev
+mode=0600
+devnum=1
+
+dev/sda
+type=blockdev
+mode=0600
+devnum=2
+
+EOF
+
+fspec-tar < t.fspec | fspec-fromtar > got.fspec
+diff -u want.fspec got.fspec
 
 # XXX fixme
-#fspec-cpio < t.fspec | fspec-fromcpio > out.fspec
-#diff -u t.fspec out.fspec
+#fspec-cpio < t.fspec | fspec-fromcpio > got.fspec
+#diff -u want.fspec got.fspec


### PR DESCRIPTION
Though this field can be omitted, this is just a convenience to
make it easier to write fspec files. The canonical form produced
by the tools should include the mode for consistency.