### PR TITLE
fspec-fromdir: Add ability to select the parts of the directory to index

### DIFF
--- a/test/0002-fspec-fromdir-sanity.test
+++ b/test/0002-fspec-fromdir-sanity.test
@@ -30,5 +30,5 @@ target=some/target
 
 EOF
 
-fspec-fromdir -r ./foo > got.fspec
+fspec-fromdir -r -C foo > got.fspec
 diff -u want.fspec got.fspec


### PR DESCRIPTION
Currently, fspec-fromdir can only index an entire directory, but
it may be useful to include only certain contents, for instance to
ignore .git or other unwanted files.

To support this, change the existing chdir operand to the -C option
(a convention used by a variety of other tools), and use any operands
as a list of contents under that directory to include. If no operands
are present, the entire directory is indexed.