### PR TITLE
Support more libarchive formats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.o
+/src/fspec-archive
 /src/fspec-tar
 /src/fspec-cpio
 /src/fspec-fromarchive

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 *.o
 /src/fspec-tar
 /src/fspec-cpio
-/src/fspec-fomtar
-/src/fspec-fomcpop
+/src/fspec-fromarchive
 /src/fspec-fromdir

--- a/Makefile
+++ b/Makefile
@@ -9,24 +9,20 @@ LDLIBS=-l archive
 BIN=\
 	src/fspec-tar\
 	src/fspec-cpio\
-	src/fspec-fromtar\
-	src/fspec-fromcpio\
+	src/fspec-fromarchive\
 	src/fspec-fromdir\
 	src/fspec-filldirs
 
 OBJ=\
 	src/fspec-tar.o\
 	src/fspec-cpio.o\
-	src/fspec-fromtar.o\
-	src/fspec-fromcpio.o\
+	src/fspec-fromarchive.o\
 	src/fspec-fromdir.o
 
 CLEAN=\
 	src/fspec-tar\
 	src/fspec-cpio\
-	src/fspec-fromtar\
-	src/fspec-fromcpio\
-	src/fspec-fromiso\
+	src/fspec-fromarchive\
 	src/fspec-fromdir\
 	$(OBJ)
 
@@ -39,20 +35,17 @@ src/fspec-tar.o: src/fspec-archive.c
 src/fspec-cpio.o: src/fspec-archive.c
 	$(CC) $(CFLAGS) -D OUT_FORMAT_CPIO=1 -c -o $@ src/fspec-archive.c
 
-src/fspec-fromtar.o: src/fspec-fromarchive.c
-	$(CC) $(CFLAGS) -D IN_FORMAT_TAR=1 -c -o $@ src/fspec-fromarchive.c
-
-src/fspec-fromcpio.o: src/fspec-fromarchive.c
-	$(CC) $(CFLAGS) -D IN_FORMAT_CPIO=1 -c -o $@ src/fspec-fromarchive.c
-
 src/fspec-fromdir.o: src/fspec-fromdir.c
 	$(CC) $(CFLAGS) -c -o $@ src/fspec-fromdir.c
+
+.c.o:
+	$(CC) $(CFLAGS) -c -o $@ $<
 
 .o:
 	$(CC) $(LDFLAGS) -o $@ $< $(LDLIBS)
 
 .PHONY: test
-test: $(BIN)
+test: all
 	./test/run-all
 
 .PHONY: install

--- a/Makefile
+++ b/Makefile
@@ -7,42 +7,35 @@ CFLAGS+=-Wall -Wpedantic
 LDLIBS=-l archive
 
 BIN=\
-	src/fspec-tar\
-	src/fspec-cpio\
+	src/fspec-archive\
 	src/fspec-fromarchive\
 	src/fspec-fromdir\
 	src/fspec-filldirs
 
 OBJ=\
-	src/fspec-tar.o\
-	src/fspec-cpio.o\
+	src/fspec-archive.o\
 	src/fspec-fromarchive.o\
 	src/fspec-fromdir.o
 
 CLEAN=\
 	src/fspec-tar\
 	src/fspec-cpio\
+	src/fspec-archive\
 	src/fspec-fromarchive\
 	src/fspec-fromdir\
 	$(OBJ)
 
 .PHONY: all
-all: $(BIN)
-
-src/fspec-tar.o: src/fspec-archive.c
-	$(CC) $(CFLAGS) -D OUT_FORMAT_TAR=1 -c -o $@ src/fspec-archive.c
-
-src/fspec-cpio.o: src/fspec-archive.c
-	$(CC) $(CFLAGS) -D OUT_FORMAT_CPIO=1 -c -o $@ src/fspec-archive.c
-
-src/fspec-fromdir.o: src/fspec-fromdir.c
-	$(CC) $(CFLAGS) -c -o $@ src/fspec-fromdir.c
+all: $(BIN) src/fspec-tar src/fspec-cpio
 
 .c.o:
 	$(CC) $(CFLAGS) -c -o $@ $<
 
 .o:
 	$(CC) $(LDFLAGS) -o $@ $< $(LDLIBS)
+
+src/fspec-tar src/fspec-cpio:
+	ln -sf fspec-archive $@
 
 .PHONY: test
 test: all
@@ -52,6 +45,8 @@ test: all
 install: all
 	mkdir -p $(DESTDIR)$(BINDIR)
 	cp $(BIN) $(DESTDIR)$(BINDIR)
+	ln -sf fspec-archive $(DESTDIR)$(BINDIR)/fspec-tar
+	ln -sf fspec-archive $(DESTDIR)$(BINDIR)/fspec-cpio
 
 .PHONY: clean
 clean:

--- a/src/fspec-archive.c
+++ b/src/fspec-archive.c
@@ -53,18 +53,24 @@ main(int argc, char **argv)
     int datafd = -1;
     struct archive *a = NULL;
     struct archive_entry *entry = NULL;
+    const char *prog;
+
+    prog = argc ? strrchr(argv[0], '/') : NULL;
+    prog = prog ? prog + 1 : argv[0];
 
     a = archive_write_new();
     entry = archive_entry_new();
     if (!a || !entry)
         errx(1, "alloc failure");
-#if defined(OUT_FORMAT_CPIO)
-    archive_write_set_format_cpio_newc(a);
-#elif defined(OUT_FORMAT_TAR)
-    archive_write_set_format_pax_restricted(a);
-#else
-#error "define OUT_FORMAT_CPIO or OUT_FORMAT_TAR"
-#endif
+
+    if (prog) {
+        if (strcmp(prog, "fspec-tar") == 0)
+            archive_write_set_format_pax_restricted(a);
+        else if (strcmp(prog, "fspec-cpio") == 0)
+            archive_write_set_format_cpio_newc(a);
+    }
+    if (!archive_format(a))
+        errx(1, "archive format could not be inferred");
 
     if (argc == 1) {
         input = stdin;

--- a/src/fspec-fromarchive.c
+++ b/src/fspec-fromarchive.c
@@ -63,14 +63,6 @@ main (int argc, char **argv)
     if (!a)
         errx(1, "alloc fail");
 
-#if defined(IN_FORMAT_CPIO)
-    archive_read_support_format_cpio(a);
-#elif defined(IN_FORMAT_TAR)
-    archive_read_support_format_tar(a);
-    archive_read_support_format_gnutar(a);
-#else
-#error "define IN_FORMAT_CPIO or IN_FORMAT_TAR"
-#endif
     archive_read_support_format_all(a);
     r = archive_read_open_filename(a, NULL, 16384);
     if (r != ARCHIVE_OK)

--- a/test/0001-fspec-archive-sanity.test
+++ b/test/0001-fspec-archive-sanity.test
@@ -73,6 +73,6 @@ EOF
 
 for fmt in tar cpio
 do
-  fspec-$fmt < t.fspec | fspec-from$fmt > got.fspec
+  fspec-$fmt < t.fspec | fspec-fromarchive > got.fspec
   diff -u want.fspec got.fspec
 done

--- a/test/0003-fspec-archive-dirdata.test
+++ b/test/0003-fspec-archive-dirdata.test
@@ -10,7 +10,7 @@ source=./foo.txt
 
 EOF
 
-fspec-tar < t.fspec | fspec-fromtar -d data > out.fspec
+fspec-tar < t.fspec | fspec-fromarchive -d data > out.fspec
 dataname="$(echo data/*)"
 
 


### PR DESCRIPTION
I noticed that both `fspec-fromtar` and `fspec-fromcpio` already support all archive formats, so I don't think it makes sense for them to be separate tools.

Along these same lines, we can support all archive formats in `fspec-archive` by adding an option to set the output archive type. We can then replace `fspec-tar` and `fspec-cpio` with a symlink to `fspec-archive`, and auto-detect the output format based on argv[0].